### PR TITLE
update partialSigsCountAfterSignature condition to check for correct number of signatures

### DIFF
--- a/RemoteSigner/Function.cs
+++ b/RemoteSigner/Function.cs
@@ -164,12 +164,15 @@ public class Function
                         //We check that the partial signatures number has changed, otherwise finalize inmediately
                         var partialSigsCountAfterSignature =
                             parsedPSBT.Inputs.Sum(x => x.PartialSigs.Count);
-
+                        
+                        //We should have added a signature for each input, plus already existing signatures
+                        var expectedPartialSigs = partialSigsCount + parsedPSBT.Inputs.Count;
+                        
                         if (partialSigsCountAfterSignature == 0 ||
-                            partialSigsCountAfterSignature != parsedPSBT.Inputs.Count)
+                            partialSigsCountAfterSignature != expectedPartialSigs)
                         {
                             var invalidNoOfPartialSignatures =
-                                $"Invalid expected number of partial signatures after signing the PSBT, expected: {parsedPSBT.Inputs.Count}, actual: {partialSigsCountAfterSignature}";
+                                $"Invalid expected number of partial signatures after signing the PSBT, expected: {expectedPartialSigs}, actual: {partialSigsCountAfterSignature}";
                             
                             throw new ArgumentException(
                                 invalidNoOfPartialSignatures);

--- a/RemoteSigner/Function.cs
+++ b/RemoteSigner/Function.cs
@@ -166,10 +166,10 @@ public class Function
                             parsedPSBT.Inputs.Sum(x => x.PartialSigs.Count);
 
                         if (partialSigsCountAfterSignature == 0 ||
-                            partialSigsCountAfterSignature <= partialSigsCount)
+                            partialSigsCountAfterSignature != parsedPSBT.Inputs.Count)
                         {
                             var invalidNoOfPartialSignatures =
-                                $"Invalid expected number of partial signatures after signing the PSBT, expected: {partialSigsCount + 1}, actual: {partialSigsCountAfterSignature}";
+                                $"Invalid expected number of partial signatures after signing the PSBT, expected: {parsedPSBT.Inputs.Count}, actual: {partialSigsCountAfterSignature}";
                             
                             throw new ArgumentException(
                                 invalidNoOfPartialSignatures);

--- a/RemoteSigner/Readme.md
+++ b/RemoteSigner/Readme.md
@@ -105,5 +105,5 @@ docker tag registry.gitlab.com/clovrlabs/lightningnetwork/fundsigner:develop 839
 
 aws ecr get-login-password --region eu-central-1 | docker login --username AWS --password-stdin 839166930136.dkr.ecr.eu-central-1.amazonaws.com
 
-docker push 839166930136.dkr.ecr.eu-central-1.amazonaws.com/RemoteSigner:latest
+docker push 839166930136.dkr.ecr.eu-central-1.amazonaws.com/nodeguardremotesigner:latest
 ```


### PR DESCRIPTION
fix(Function.cs): update partialSigsCountAfterSignature condition to check for correct number of signatures

docs(Readme.md): update docker push command to use correct image name 'nodeguardremotesigner'