### PR TITLE
Bump NBitcoin to 10.0.9 and AWS SDK to v4

### DIFF
--- a/RemoteSigner.Tests/RemoteSigner.Tests.csproj
+++ b/RemoteSigner.Tests/RemoteSigner.Tests.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>RemoteSigner.Tests</RootNamespace> 
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="3.3.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="4.2.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/RemoteSigner/Function.cs
+++ b/RemoteSigner/Function.cs
@@ -7,7 +7,7 @@ using Amazon.KeyManagementService.Model;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.Core;
 using Amazon.Lambda.Serialization.SystemTextJson;
-using Amazon.Runtime;
+using Amazon.Runtime.CredentialManagement;
 using NBitcoin;
 
 [assembly:
@@ -56,8 +56,10 @@ public class Function
             if (requestBody == null) throw new ArgumentNullException(nameof(requestBody), "Request body not found");
 
 #if DEBUG
-            var kmsClient = new AmazonKeyManagementServiceClient(new StoredProfileAWSCredentials("default"),
-                RegionEndpoint.EUCentral1);
+            //AWS SDK v4 removed StoredProfileAWSCredentials; resolve the "default" profile explicitly
+            if (!new CredentialProfileStoreChain().TryGetAWSCredentials("default", out var debugCredentials))
+                throw new InvalidOperationException("AWS profile 'default' was not found");
+            var kmsClient = new AmazonKeyManagementServiceClient(debugCredentials, RegionEndpoint.EUCentral1);
 #else
             var kmsClient = new AmazonKeyManagementServiceClient();
 #endif

--- a/RemoteSigner/RemoteSigner.csproj
+++ b/RemoteSigner/RemoteSigner.csproj
@@ -13,11 +13,11 @@
     <AssemblyName>RemoteSigner</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
-    <PackageReference Include="AWSSDK.Core" Version="3.7.106.34" />
-    <PackageReference Include="AWSSDK.KeyManagementService" Version="3.7.102.4" />
-    <PackageReference Include="NBitcoin" Version="7.0.25" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="3.0.1" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="3.3.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.1" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.101.1" />
+    <PackageReference Include="AWSSDK.KeyManagementService" Version="4.0.100.9" />
+    <PackageReference Include="NBitcoin" Version="10.0.9" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- NBitcoin 7.0.25 -> 10.0.9 (parity with NodeGuard's move to 10.x)
- AWSSDK.Core 3.7.106.34 -> 4.0.101.1, AWSSDK.KeyManagementService 3.7.102.4 -> 4.0.100.9
- Amazon.Lambda.Core 2.1.0 -> 3.3.0, APIGatewayEvents 2.6.0 -> 3.0.1,
  Serialization.SystemTextJson 2.3.1 -> 3.0.1, TestUtilities 2.0.0 -> 4.2.0
- AWS SDK v4 removed StoredProfileAWSCredentials: the DEBUG-only KMS client
  now resolves the 'default' profile via CredentialProfileStoreChain

All tests pass in both Debug and Release (SignTest PSBT vectors included).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>